### PR TITLE
Fixes #11

### DIFF
--- a/lib/currency_text_input_formatter.dart
+++ b/lib/currency_text_input_formatter.dart
@@ -27,31 +27,47 @@ class CurrencyTextInputFormatter extends TextInputFormatter {
   @override
   TextEditingValue formatEditUpdate(
       TextEditingValue oldValue, TextEditingValue newValue) {
+    bool isInsertedCharacter =
+        oldValue.text.length + 1 == newValue.text.length &&
+            newValue.text.startsWith(oldValue.text);
+    bool isRemovedCharacter =
+        oldValue.text.length - 1 == newValue.text.length &&
+            oldValue.text.startsWith(newValue.text);
+
+    // Apparently, Flutter has a bug where the framework calls
+    // formatEditUpdate twice, or even four times, after a backspace press (see
+    // https://github.com/gtgalone/currency_text_input_formatter/issues/11).
+    // However, only the first of these calls has inputs which are consistent
+    // with a character insertion/removal at the end (which is the most common
+    // use case of editing the TextField - the others being insertion/removal
+    // in the middle, or pasting text onto the TextField). This condition
+    // fixes a problem where a character wasn't properly erased after a
+    // backspace press, when this Flutter bug was present. This comes at the
+    // cost of losing insertion/removal in the middle and pasting text.
+    if (!isInsertedCharacter && !isRemovedCharacter) {
+      return oldValue;
+    }
+
     final format = NumberFormat.currency(
         locale: locale, decimalDigits: decimalDigits, symbol: symbol);
     bool isNegative = newValue.text.startsWith('-');
     String newText = newValue.text.replaceAll(RegExp('[^0-9]'), '');
 
+    // If the user wants to remove a digit, but the last character of the
+    // formatted text is not a digit (for example, "1,00 €"), we need to remove
+    // the digit manually.
+    if (isRemovedCharacter && !_lastCharacterIsDigit(oldValue.text)) {
+      newText = newText.substring(0, newText.length - 1);
+    }
+
     if (newText.trim() == '') {
       return newValue.copyWith(
-          text: isNegative ? '-' : '',
-          selection: TextSelection.collapsed(offset: isNegative ? 1 : 0));
-    } else if (newText == '0') {
-      newValue.copyWith(
           text: isNegative ? '-' : '',
           selection: TextSelection.collapsed(offset: isNegative ? 1 : 0));
     } else if (newText == '00' || newText == '000') {
       return TextEditingValue(
           text: isNegative ? '-' : '',
           selection: TextSelection.collapsed(offset: isNegative ? 1 : 0));
-    }
-
-    String newTextWithoutSymbol =
-        newValue.text.replaceAll(RegExp('[^0-9.,]'), '');
-    String oldTextWithoutSymbol =
-        oldValue.text.replaceAll(RegExp('[^0-9.,]'), '');
-    if (newTextWithoutSymbol == oldTextWithoutSymbol) {
-      newText = newText.substring(0, newText.length - 1);
     }
 
     dynamic newInt = int.parse(newText);
@@ -63,5 +79,10 @@ class CurrencyTextInputFormatter extends TextInputFormatter {
       text: newString,
       selection: TextSelection.collapsed(offset: newString.length),
     );
+  }
+
+  static bool _lastCharacterIsDigit(String text) {
+    String lastChar = text.substring(text.length - 1);
+    return RegExp('[0-9]').hasMatch(lastChar);
   }
 }

--- a/test/currency_text_input_formatter_test.dart
+++ b/test/currency_text_input_formatter_test.dart
@@ -59,8 +59,100 @@ void main() {
 
   test('Formats longer string correctly', () {
     var formatter = CurrencyTextInputFormatter();
-    var value = formatter.formatEditUpdate(
-        TextEditingValue.empty, TextEditingValue(text: '10050'));
-    expect(value.text, '100.50');
+    var value = formatter.formatEditUpdate(TextEditingValue(text: '1,234.56'),
+        TextEditingValue(text: '1,234.567'));
+    expect(value.text, '12,345.67');
+  });
+
+  group('Erasing last digit works', () {
+    CurrencyTextInputFormatter formatter;
+    String eraseLast(String text) => formatter
+        .formatEditUpdate(
+          TextEditingValue(text: text),
+          TextEditingValue(text: removeLast(text)),
+        )
+        .text;
+
+    test('With the default parameters', () {
+      formatter = CurrencyTextInputFormatter();
+
+      expect(eraseLast('12,345.67'), '1,234.56');
+      expect(eraseLast('1,234.56'), '123.45');
+      expect(eraseLast('123.45'), '12.34');
+      expect(eraseLast('12.34'), '1.23');
+      expect(eraseLast('1.23'), '0.12');
+      expect(eraseLast('0.12'), '0.01');
+      expect(eraseLast('0.01'), '');
+    });
+
+    test('With a suffix symbol', () {
+      formatter = CurrencyTextInputFormatter(symbol: '€', locale: 'es');
+
+      var nbsp = String.fromCharCode(0xa0);
+      expect(eraseLast('12.345,67' + nbsp + '€'), '1.234,56' + nbsp + '€');
+      expect(eraseLast('1.234,56' + nbsp + '€'), '123,45' + nbsp + '€');
+      expect(eraseLast('123,45' + nbsp + '€'), '12,34' + nbsp + '€');
+      expect(eraseLast('12,34' + nbsp + '€'), '1,23' + nbsp + '€');
+      expect(eraseLast('1,23' + nbsp + '€'), '0,12' + nbsp + '€');
+      expect(eraseLast('0,12' + nbsp + '€'), '0,01' + nbsp + '€');
+      expect(eraseLast('0,01' + nbsp + '€'), '');
+    });
+  });
+
+  group("Erasing last digit works despite Flutter's bug", () {
+    // Apparently, Flutter has a bug where the framework calls
+    // formatEditUpdate twice, or even four times, after a backspace press. It
+    // might be related to https://github.com/flutter/flutter/issues/48608.
+    // This only happens on some devices, when the keyboard type is set to
+    // a keyboard with numbers. These tests simulate the bug and check that
+    // the formatter works despite this problem. For discussion, see
+    // https://github.com/gtgalone/currency_text_input_formatter/issues/11.
+
+    CurrencyTextInputFormatter formatter;
+    String formatEditUpdate(String oldText, String newText) => formatter
+        .formatEditUpdate(
+          TextEditingValue(text: oldText),
+          TextEditingValue(text: newText),
+        )
+        .text;
+
+    String eraseWithBugFormatterCalledTwice(String text) {
+      String output1 = formatEditUpdate(text, removeLast(text));
+      String output2 = formatEditUpdate(output1, removeLast(text));
+      return output2;
+    }
+
+    String eraseWithBugFormatterCalledFourTimes(String text) {
+      String output1 = formatEditUpdate(text, removeLast(text));
+      String output2 = formatEditUpdate(output1, removeLast(text));
+      String output3 = formatEditUpdate(output2, output1);
+      String output4 = formatEditUpdate(output3, output2);
+      return output4;
+    }
+
+    test('With the default parameters', () {
+      formatter = CurrencyTextInputFormatter();
+
+      expect(eraseWithBugFormatterCalledTwice('0.12'), '0.01');
+      expect(eraseWithBugFormatterCalledTwice('123,456.78'), '12,345.67');
+      expect(eraseWithBugFormatterCalledFourTimes('0.12'), '0.01');
+      expect(eraseWithBugFormatterCalledFourTimes('123,456.78'), '12,345.67');
+    });
+
+    test('With a suffix symbol', () {
+      formatter = CurrencyTextInputFormatter(symbol: '€', locale: 'es');
+
+      var nbsp = String.fromCharCode(0xa0);
+      expect(eraseWithBugFormatterCalledTwice('0,12' + nbsp + '€'),
+          '0,01' + nbsp + '€');
+      expect(eraseWithBugFormatterCalledTwice('123.456,78' + nbsp + '€'),
+          '12.345,67' + nbsp + '€');
+      expect(eraseWithBugFormatterCalledFourTimes('0,12' + nbsp + '€'),
+          '0,01' + nbsp + '€');
+      expect(eraseWithBugFormatterCalledFourTimes('123.456,78' + nbsp + '€'),
+          '12.345,67' + nbsp + '€');
+    });
   });
 }
+
+String removeLast(String s) => s.substring(0, s.length - 1);


### PR DESCRIPTION
Added tests for digit removal and also tests reproducing the Flutter bug discussed in #11. And fixes it by assuming that, if the change is not a insertion/removal at end, then it's an invalid call to the formatter (due to the Flutter bug), and just returns the old value.