### PR TITLE
added option to turn off grouping

### DIFF
--- a/lib/currency_text_input_formatter.dart
+++ b/lib/currency_text_input_formatter.dart
@@ -18,11 +18,13 @@ class CurrencyTextInputFormatter extends TextInputFormatter {
     this.symbol = '',
     this.locale,
     this.decimalDigits = 2,
+    this.turnOffGrouping = false,
   });
 
   final String symbol;
   final String locale;
   final int decimalDigits;
+  final bool turnOffGrouping;
 
   @override
   TextEditingValue formatEditUpdate(
@@ -49,6 +51,9 @@ class CurrencyTextInputFormatter extends TextInputFormatter {
 
     final format = NumberFormat.currency(
         locale: locale, decimalDigits: decimalDigits, symbol: symbol);
+    if (turnOffGrouping) {
+      format.turnOffGrouping();
+    }
     bool isNegative = newValue.text.startsWith('-');
     String newText = newValue.text.replaceAll(RegExp('[^0-9]'), '');
 


### PR DESCRIPTION
This option allows turning off grouping. For example:
- grouping on (current behavior): `10,000.00`
- grouping off: `10000.00`

resolves https://github.com/gtgalone/currency_text_input_formatter/issues/14