### PR TITLE
Supporting format for double values

### DIFF
--- a/lib/currency_text_input_formatter.dart
+++ b/lib/currency_text_input_formatter.dart
@@ -181,4 +181,17 @@ class CurrencyTextInputFormatter extends TextInputFormatter {
     _formatter(newText);
     return _newString;
   }
+
+  // Method for formatting value.
+  String formatDouble(double value) {
+    if (enableNegative) {
+      _isNegative = value.isNegative;
+    } else {
+      _isNegative = false;
+    }
+
+    final String newText = value.toStringAsFixed(decimalDigits ?? 0).replaceAll(RegExp('[^0-9]'), '');
+    _formatter(newText);
+    return _newString;
+  }
 }


### PR DESCRIPTION
When trying to use the input switching between screens, restoring the value from a double with not enought decimal numbers results in the formatter dividing the value by 10.

For instance:
value = 15.3
currencyFormatter.format(value.toString()) // with decimalPlaces: 2
currencyFormatter.getFormattedValue() // will output 1.53