### PR TITLE
removed turnoffGrouping only for the constructor that accepts format

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -192,26 +192,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.0"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "2.0.1"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "2.0.1"
   logging:
     dependency: transitive
     description:
@@ -240,10 +240,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.11.0"
   mime:
     dependency: transitive
     description:
@@ -413,26 +413,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "7ee446762c2c50b3bd4ea96fe13ffac69919352bd3b4b17bac3f3465edc58073"
+      sha256: a1f7595805820fcc05e5c52e3a231aedd0b72972cb333e8c738a8b1239448b6f
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.2"
+    version: "1.24.9"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.6.1"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "2bc4b4ecddd75309300d8096f781c0e3280ca1ef85beda558d33fcbedc2eead4"
+      sha256: a757b14fc47507060a162cc2530d9a4a2f92f5100a952c7443b5cad5ef5b106a
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.5.9"
   typed_data:
     dependency: transitive
     description:
@@ -453,10 +453,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: a2662fb1f114f4296cf3f5a50786a2d888268d7776cf681aa17d660ffa23b246
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
       url: "https://pub.dev"
     source: hosted
-    version: "14.0.0"
+    version: "13.0.0"
   watcher:
     dependency: transitive
     description:
@@ -498,5 +498,4 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.3.0-0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  dart: ">=3.2.0 <4.0.0"

--- a/lib/currency_text_input_formatter.dart
+++ b/lib/currency_text_input_formatter.dart
@@ -14,8 +14,6 @@ class CurrencyTextInputFormatter extends TextInputFormatter {
   ///
   /// [format] Number format .
   ///
-  /// [turnOffGrouping] argument is used to locale of NumberFormat currency.
-  ///
   /// [enableNegative] argument is used to enable negative value.
   ///
   /// [inputDirection] argument is used to set input direction.
@@ -27,20 +25,14 @@ class CurrencyTextInputFormatter extends TextInputFormatter {
   /// [onChange] argument is used to set callback when value is changed.
   factory CurrencyTextInputFormatter(
     NumberFormat format, {
-    bool turnOffGrouping = false,
     bool enableNegative = true,
     InputDirection inputDirection = InputDirection.right,
     int? minValue,
     int? maxValue,
     Function(String)? onChange,
   }) {
-    if (turnOffGrouping) {
-      format.turnOffGrouping();
-    }
-
     return CurrencyTextInputFormatter._(
       format,
-      turnOffGrouping,
       enableNegative,
       inputDirection,
       minValue,
@@ -51,7 +43,6 @@ class CurrencyTextInputFormatter extends TextInputFormatter {
 
   CurrencyTextInputFormatter._(
     this.format,
-    this.turnOffGrouping,
     this.enableNegative,
     this.inputDirection,
     this.minValue,
@@ -109,7 +100,6 @@ class CurrencyTextInputFormatter extends TextInputFormatter {
 
     return CurrencyTextInputFormatter._(
       format,
-      turnOffGrouping,
       enableNegative,
       inputDirection,
       minValue,
@@ -160,7 +150,6 @@ class CurrencyTextInputFormatter extends TextInputFormatter {
 
     return CurrencyTextInputFormatter._(
       format,
-      turnOffGrouping,
       enableNegative,
       inputDirection,
       minValue,
@@ -171,13 +160,6 @@ class CurrencyTextInputFormatter extends TextInputFormatter {
 
   /// NumberFormat
   final NumberFormat format;
-
-  /// Defaults `turnOffGrouping` is false.
-  ///
-  /// Explicitly turn off any grouping (e.g. by thousands) in this format.
-  /// This is used in compact number formatting, where we omit the normal grouping.
-  /// Best to know what you're doing if you call it.
-  final bool turnOffGrouping;
 
   /// Defaults `enableNegative` is true.
   ///

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -175,26 +175,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.0"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "2.0.1"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "2.0.1"
   logging:
     dependency: transitive
     description:
@@ -223,10 +223,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.11.0"
   mime:
     dependency: transitive
     description:
@@ -372,26 +372,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "7ee446762c2c50b3bd4ea96fe13ffac69919352bd3b4b17bac3f3465edc58073"
+      sha256: a1f7595805820fcc05e5c52e3a231aedd0b72972cb333e8c738a8b1239448b6f
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.2"
+    version: "1.24.9"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.6.1"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "2bc4b4ecddd75309300d8096f781c0e3280ca1ef85beda558d33fcbedc2eead4"
+      sha256: a757b14fc47507060a162cc2530d9a4a2f92f5100a952c7443b5cad5ef5b106a
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.5.9"
   typed_data:
     dependency: transitive
     description:
@@ -412,10 +412,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: a2662fb1f114f4296cf3f5a50786a2d888268d7776cf681aa17d660ffa23b246
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
       url: "https://pub.dev"
     source: hosted
-    version: "14.0.0"
+    version: "13.0.0"
   watcher:
     dependency: transitive
     description:
@@ -449,5 +449,4 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.3.0-0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  dart: ">=3.2.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  intl: ^0.19.0
+  intl: ">=0.17.0-0 <=0.19.0"
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
I'm sorry to bother again in a such a short notice but I caught something that could lead to an error. 
 
"The constructor of CurrencyTextInputFormatter does not necessarily require the turnOffGrouping parameter, as this functionality can be managed through the format parameter instance itself. Including turnOffGrouping in the main constructor may introduce potential errors." 

CurrencyTextInputFormatter.currency and CurrencyTextInputFormatter.simpleCurrency they are still keeping turnOffGrouping for the library functionality. 

I've also changed the CurrencyTextInputFormatter to also accept olders intl dependencies from intl: '>=0.17.0-0 <=0.19.0'. Having intl since 0.17.0 won't affect CurrencyTextInputFormatter its the same range used by [easy_localization package](https://github.com/aissat/easy_localization/blob/63a39744ca18e38e51b5d30dbb63b95925b27ef5/pubspec.yaml#L17).
