### PR TITLE
Handle parsing of null decimalDigits

### DIFF
--- a/lib/currency_text_input_formatter.dart
+++ b/lib/currency_text_input_formatter.dart
@@ -200,7 +200,7 @@ class CurrencyTextInputFormatter extends TextInputFormatter {
 
   num _parseStrToNum(String text) {
     num value = num.tryParse(text) ?? 0;
-    if (format.decimalDigits! > 0) {
+    if (format.decimalDigits != null && format.decimalDigits! > 0) {
       value /= pow(10, format.decimalDigits!);
     }
     return value;

--- a/test/currency_text_input_formatter_test.dart
+++ b/test/currency_text_input_formatter_test.dart
@@ -26,6 +26,14 @@ void main() {
     expect(value.text, '@0');
   });
 
+  test('Formats input correctly when decimal digits are null', () {
+    final CurrencyTextInputFormatter formatter =
+        CurrencyTextInputFormatter.currency(symbol: '@');
+    final TextEditingValue value = formatter.formatEditUpdate(
+        TextEditingValue.empty, const TextEditingValue(text: '0'));
+    expect(value.text, '@0.00');
+  });
+
   test('Formats input with symbol, if symbol is provided', () {
     final CurrencyTextInputFormatter formatter =
         CurrencyTextInputFormatter.currency(symbol: '@');


### PR DESCRIPTION
When creating a formatter with a null `decimalDigits` and using the `formatString` method, a `TypeError` is thrown because a non-null assertion operator is used when checking if `decimalDigits` is positive.

```dart
  num _parseStrToNum(String text) {
    num value = num.tryParse(text) ?? 0;
    // THIS LINE
    if (format.decimalDigits! > 0) {
      value /= pow(10, format.decimalDigits!);
    }
    return value;
  }
```