### PR TITLE
Fix: Allow empty input when inputDirection is left (Fixes #58)

### DIFF
--- a/lib/currency_text_input_formatter.dart
+++ b/lib/currency_text_input_formatter.dart
@@ -227,6 +227,13 @@ class CurrencyTextInputFormatter extends TextInputFormatter {
   ) {
     final bool isLeft = inputDirection == InputDirection.left;
     if (isLeft) {
+      // Allow an empty field
+      if (newValue.text.isEmpty) {
+        _newNum = 0;
+        _newString = '';
+        return newValue;
+      }
+
       final List<String> nums = newValue.text.split('.');
       if (nums.length > 2) {
         return oldValue;
@@ -234,6 +241,7 @@ class CurrencyTextInputFormatter extends TextInputFormatter {
       if (nums.length == 2 && (nums[1].length > (format.decimalDigits ?? 2))) {
         return oldValue;
       }
+      // Prevents the user from entering a dot or comma at the beginning of the text
       final double? v = double.tryParse(newValue.text);
       if (v == null) {
         return oldValue;
@@ -298,7 +306,6 @@ class CurrencyTextInputFormatter extends TextInputFormatter {
       );
     }
 
-    /// Call onChange callback
     if (onChange != null) {
       onChange!(_newString);
     }

--- a/lib/currency_text_input_formatter.dart
+++ b/lib/currency_text_input_formatter.dart
@@ -225,6 +225,11 @@ class CurrencyTextInputFormatter extends TextInputFormatter {
     TextEditingValue oldValue,
     TextEditingValue newValue,
   ) {
+    // Prevent any space characters from being inserted
+    if (newValue.text.contains(' ')) {
+      return oldValue;
+    }
+
     final bool isLeft = inputDirection == InputDirection.left;
     if (isLeft) {
       // Allow an empty field

--- a/test/currency_text_input_formatter_test.dart
+++ b/test/currency_text_input_formatter_test.dart
@@ -140,6 +140,20 @@ void main() {
         reason: 'Dot should not be allowed as first character');
   });
 
+  test('Does not allow space character in input', () {
+    final CurrencyTextInputFormatter formatter =
+        CurrencyTextInputFormatter.currency();
+
+    const TextEditingValue oldValue = TextEditingValue(text: '0');
+    const TextEditingValue newValue = TextEditingValue(text: '0 ');
+    final TextEditingValue result =
+        formatter.formatEditUpdate(oldValue, newValue);
+
+    // Since spaces are not allowed, the formatter should return the old value.
+    expect(result.text, oldValue.text,
+        reason: 'Space characters should be restricted.');
+  });
+
   test('Does not allow comma as first character when input direction is left',
       () {
     final CurrencyTextInputFormatter formatter =

--- a/test/currency_text_input_formatter_test.dart
+++ b/test/currency_text_input_formatter_test.dart
@@ -99,6 +99,62 @@ void main() {
     expect(formatter.getDouble(), 123.25);
   });
 
+  test('Allows empty field when input direction is left', () {
+    final CurrencyTextInputFormatter formatter =
+        CurrencyTextInputFormatter.currency(
+      inputDirection: InputDirection.left,
+    );
+    // Simulate an existing non-empty value
+    const TextEditingValue oldValue = TextEditingValue(text: '1');
+    // New value is an empty string
+    const TextEditingValue newValue = TextEditingValue(text: '');
+    final TextEditingValue value =
+        formatter.formatEditUpdate(oldValue, newValue);
+    expect(value.text, '', reason: 'Empty input should remain empty');
+  });
+
+  test('Empty input remains empty with left input direction', () {
+    final CurrencyTextInputFormatter formatter =
+        CurrencyTextInputFormatter.currency(
+      inputDirection: InputDirection.left,
+    );
+    final TextEditingValue value = formatter.formatEditUpdate(
+      TextEditingValue.empty,
+      const TextEditingValue(text: ''),
+    );
+    expect(value.text, '', reason: 'Empty input should remain empty');
+  });
+
+  test('Does not allow dot as first character when input direction is left',
+      () {
+    final CurrencyTextInputFormatter formatter =
+        CurrencyTextInputFormatter.currency(
+      inputDirection: InputDirection.left,
+    );
+    const TextEditingValue oldValue = TextEditingValue.empty;
+    final TextEditingValue result = formatter.formatEditUpdate(
+      oldValue,
+      const TextEditingValue(text: '.'),
+    );
+    expect(result.text, '',
+        reason: 'Dot should not be allowed as first character');
+  });
+
+  test('Does not allow comma as first character when input direction is left',
+      () {
+    final CurrencyTextInputFormatter formatter =
+        CurrencyTextInputFormatter.currency(
+      inputDirection: InputDirection.left,
+    );
+    const TextEditingValue oldValue = TextEditingValue.empty;
+    final TextEditingValue result = formatter.formatEditUpdate(
+      oldValue,
+      const TextEditingValue(text: ','),
+    );
+    expect(result.text, '',
+        reason: 'Comma should not be allowed as first character');
+  });
+
   group('Erasing last digit works', () {
     CurrencyTextInputFormatter formatter =
         CurrencyTextInputFormatter.currency();


### PR DESCRIPTION
While using this package, I stumbled across [issue #58](https://github.com/gtgalone/currency_text_input_formatter/issues/58) myself and decided to contribute a fix.

### ✅ Changes Included:
- Fixed the logic in `formatEditUpdate` to allow an empty string when input direction is `left`
- Added tests to ensure:
  - Empty input is valid in left-direction mode
  - Input starting with a dot (`.`) or comma (`,`) is rejected in left-direction mode
- (New) Fixed a bug where it was possible to insert a space character (e.g., `"0 "`). The formatter now rejects any input containing whitespace to prevent invalid states or formatting errors.

This improves UX for users who want to clear the input field entirely and avoids confusion when the formatter reverts their input unexpectedly. It also ensures stricter input validation by disallowing unsupported characters like spaces.